### PR TITLE
Remove APP_APN_NAME option from CMake command line

### DIFF
--- a/examples/CommonGateway/c-cellular/CMakeLists.txt
+++ b/examples/CommonGateway/c-cellular/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.6)
 
 project("Kiso Example c-cellular" C)
 
-if (NOT DEFINED APP_APN_NAME)
-   message(SEND_ERROR "APP_APN_NAME is a required parameter! Use cmake <...> -DAPP_APN_NAME='\"app-name\"' to specify.")
-endif()
-
 if(${CMAKE_CROSSCOMPILING})
    set(APP_CONFIG_PATH ${CMAKE_CURRENT_LIST_DIR}/config PARENT_SCOPE)
 
@@ -13,7 +9,6 @@ if(${CMAKE_CROSSCOMPILING})
       source/main.c
       source/App.c
    )
-   target_compile_definitions(application PRIVATE -DAPP_APN_NAME="${APP_APN_NAME}")
    target_include_directories(application PRIVATE source)
    target_link_libraries(application bsp essentials utils cellular)
 

--- a/examples/CommonGateway/c-cellular/source/AppConfig.h
+++ b/examples/CommonGateway/c-cellular/source/AppConfig.h
@@ -33,8 +33,9 @@
 #define APP_NUMBER_OF_RETRIES (UINT32_C(3))
 #define APP_SIM_PIN (NULL)
 #define APP_RAT (CELLULAR_RAT_LTE_CAT_M1)
-// #define APP_APN_NAME ("${APP_APN_NAME}")
 // clang-format on
+
+#define APP_APN_NAME ("your.apn.goes.here")              /* this needs to be replaced with your APN */
 #define APP_APN_AUTHMETHOD (CELLULAR_APNAUTHMETHOD_NONE) /* Currently the only supported option */
 #define APP_APN_USER (NULL)                              /* Currently the only supported option */
 #define APP_APN_PASSWORD (NULL)                          /* Currently the only supported option */
@@ -61,5 +62,4 @@
 #define APP_TCP_TEST_PORT (UINT16_C(7))
 #define APP_TCP_TEST_DATA ("HELLO WORLD!")
 // clang-format on
-
 #endif


### PR DESCRIPTION
- make config option consistent
- improve understandability

Signed-off-by: Lars Beseke <lars.beseke@bosch.com>