### PR TITLE
Enable plantuml in doxygen build

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -7,32 +7,19 @@ WORKDIR /kiso-project
 # Define environment variable
 ENV NAME kiso-container
 
-# Update package management
-RUN apt-get update
-
-# Install python and pip
-RUN apt-get install -y python3
-
-# Get cmake & ninja
-RUN apt-get install -y cmake ninja-build
-
-# Get latest static analysis tools
-RUN apt-get install -y clang-format clang-tidy cppcheck
-
-# Get latest gtest
-RUN apt-get install -y libgtest-dev
-
-# Get latest coverage report generator
-RUN apt-get install -y lcov
-
-# Get doxygen
-RUN apt-get install -y doxygen graphviz
-
-# Get the compilers
-RUN apt-get install -y gcc-arm-none-eabi gcc g++
-
-# Get xmllint
-RUN apt-get install -y libxml2-utils
-
-# Get Hugo for website verification
-RUN apt-get install -y hugo
+# Update package management and install necessary packages
+RUN apt-get update && apt-get install -y \
+    clang-format \
+    clang-tidy \
+    cmake \
+    cppcheck \
+    g++ \
+    gcc \
+    gcc-arm-non-eabi \
+    hugo \
+    lcov \
+    libgtest-dev \
+    libxml2-utils \
+    ninja-build \
+    plantuml \
+    python3

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -2300,7 +2300,7 @@ DIAFILE_DIRS           =
 # will not generate output for the diagram.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-PLANTUML_JAR_PATH      =
+PLANTUML_JAR_PATH      = plantuml
 
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes


### PR DESCRIPTION
PlantUML is a tool to render images from a descriptive domain-specific-language. Doxygen is able to generate diagrams when given the path to the plantuml executable. It will automatically generate UML diagrams from `@startuml ... @enduml` sections and integrate them in the documentation.

Added PlantUML package to installation in CI docker-image. Restructuring of `apt-get install ...` calls in accordance with official [best practises](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). New image needs to be built.

Example uses:
https://github.com/eclipse/kiso/blob/master/core/connectivity/cellular/include/Kiso_Cellular.h#L32-L73