### PR TITLE
Add shields.io based build and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kiso #
+# Kiso [![Build Status Badge](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fkiso%2Fjob%2Fkiso_github%2Fjob%2Fmaster%2F)](https://ci.eclipse.org/kiso/job/kiso_github/job/master/) [![License Badge](https://img.shields.io/github/license/eclipse/kiso)](https://www.eclipse.org/legal/epl-2.0/) #
 ![Kiso logo](./docs/doxygen/Kiso-logo.png)
 
 ## Introduction ##


### PR DESCRIPTION
Everyone likes badges! Now seriously, this is just some eye-candy but it freshens up the first-look a bit.

The badges are currently generated via [shields.io](https://shields.io/), which is a third-party online service to generate "shields" for public projects. Alternatively, we could install a Jenkins plug-in on our Eclipse/Kiso instance if we have the permission to do so.