### PR TITLE
Documentation for Kiso's Scope, done through Personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The Bosch Connected Devices Development Kit (CDDK) has been originally used to d
 
 Kiso (Japanese for "basis") is an Eclipse Foundation project that is using the original code base of CDDK. Kiso is transferring the Bosch proprietary licence code piece-by-piece to EPLv2 open source. Kiso's quality goals - understandability, usability, product quality, extensibility and performance - are the key factors that enable a fast prototype and product development. By this, it reduces the time to market together with minimizing technical debts for almost all kinds of IoT "Things".
 
+## Scope ##
+To learn what Kiso is and how it can help you, please have a look at our [scope](http://kiso.rempler.de:1313/1.-project-overview/scope.html) page.
+
 ## Quick start ##
 Please take a look at the [quick start](http://kiso.rempler.de:1313/3.-user-guide/quick_start.html) section in the user manual documentation.
 

--- a/docs/website/content/1. Project overview/roadmap.md
+++ b/docs/website/content/1. Project overview/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: "Roadmap"
-weight: 1
+weight: 20
 ---
 
 Kiso packages:

--- a/docs/website/content/1. Project overview/scope.md
+++ b/docs/website/content/1. Project overview/scope.md
@@ -1,0 +1,46 @@
+---
+title: "Scope"
+weight: 10
+---
+
+Who and how can Kiso help? Let's look at some user personas to answer this.
+
+## Meet Peter, the embedded device developer ##
+
+Peter is an experienced SW developer at a device manufacturer. The company's business model is selling IoT devices to
+business customers as well as directly to end users. These IoT devices are based on different MCUs with quite
+constrained system resources. They are battery driven and have at least one wireless connectivity. The typical use case
+scenario of these devices is to collect, process and then send data out via a radio interface. The data is generated via
+sensors or other HW that it connected via serial interface. Peter is developing the SW for these devices - sounds like
+fun.
+
+A full scale device development is most of the time preceded by a prototype. Martina, a friendly cloud developer, is
+frequently demoing her companies services with her self-made prototypes. These demo prototypes are using a lot of system
+resources without any power optimization or without considering a commercial use of SW licenses. So, these prototypes
+are basically of no re-use for Peter.
+
+Thus, Peter typically took some RTOS and integrated HW manufacturer drivers when available. If no drivers had been
+available he wrote them by himself. Over the last couple of years he build up a collection of SW modules and drivers.
+All of this SW modules and drivers are specifically designed for a particular use case and device. For a new project he
+copies over parts of his existing SW set. But, most of these SW parts need modifications in order to fit the new device
+and to become compatible to each other again in a new use case setup.
+
+Now, Peter read a newsletter about a new SW development kit on the block. Yeah! He found out that Kiso has a harmonized
+and compatible set of SW modules and drivers he can choose from. Also, Kiso is very well documented to easily and
+quickly start a new SW development project (even though Peter would never admit that he reads the documentation before
+the source code). The well tested SW gives him the comfort of Bosch quality and let him focus on bug hunting on his
+self-written code. He's now replacing parts of his existing SW set one by one with Kiso components.
+
+He now has much less - if not none - effort to build up a SW basis that he can start developing the IoT device
+application on. It's very convenient for him that he can just clone from an open source repository without worrying
+about licenses. All these benefits help Peter to minimize the technical debts, enable adequate development costs
+together with a shorter time to market (TTM). Thus, he's so very happy right now and exited committing his improved SW
+modules and additional drivers back to the Kiso project. He becomes an active Kiso contributor.
+
+## Meet Martina, the cloud developer ##
+
+This story is in review and will be published soon<sup>TM</sup>.
+
+## Meet Aditya, the MEMS engineer ##
+
+This story is in review and will be published soon<sup>TM</sup>.

--- a/docs/website/content/4. Contribution guide/first_contribution.md
+++ b/docs/website/content/4. Contribution guide/first_contribution.md
@@ -3,21 +3,27 @@ title: "First contribution"
 weight: 2
 ---
 
-# How can I do my first contribution?
+## How can I do my first contribution?
 
-## Prerequisite
+### Prerequisite
+
+Please, before you start writing code, have a look at the personas described in [Kiso's Scope]({{< ref "../1. Project overview/scope.md" >}}).
+They describe who Kiso is targeted for, and should taken into account in your Design & Development process.
+
 Make sure you have done the things in [‘What should I do before I get started?’](../prerequisite). Without accounts, you cannot have access rights to do certain operations. And ECA and DCO are important from a legal point of view, for both contributors and the project. Therefore you need to get them ready before going forward.
 
-## Architecture and source code
+### Architecture and source code
+
 Before you can contribute back something, you need to be pretty familiar with Kiso. First with the architecture of Kiso and then its source code.
 
 Architecture of Kiso is good start point where you can have an overview of the whole picture. Visit this [section]({{< ref "overall_architecture.md" >}}) for more information.
 
 Then it is about source code itself. After getting to know the whole picture, you need to zoom in the place you have interests, which more or less means you need to get your hands on code of a certain module, understand it and play around with it.
 
-## Tools and environment setup
+### Tools and environment setup
+
 For an easy jump start of setting up environment and tools, you can find enough information in [Quick start]({{< ref "quick_start.md" >}}).
 
-## Find a good topic to work on
+### Find a good topic to work on
 
 For sure, you want to start with something you have interests in (eg. writing a BSP for a new board). Please take a look at our [roadmap]({{< ref "roadmap.md" >}}) to see if your topic already exists in it. If not, please contact and talk to us, we will support you in defining and documenting what you would like to do.

--- a/docs/website/content/5. Frequently asked questions/FAQ.md
+++ b/docs/website/content/5. Frequently asked questions/FAQ.md
@@ -3,8 +3,11 @@ title: "FAQ"
 weight: 1
 ---
 
-# Frequently Asked Questions
+## Frequently Asked Questions
 
+**Who is Kiso for?**
+
+We have a page on that. Please have a look at [Kiso's Scope]({{< ref "../1. Project overview/scope.md" >}}).
 
 **Why is the Bosch Cross Domain Development Kit (XDK aka. XDK110) not a Kiso reference HW?**
 
@@ -16,6 +19,6 @@ Anyway, we're continuously working on extending the Kiso reference HW basis. Thu
 
 ------
 We're still collecting more frequently asked questions.
-Please feel free to contact us via Mattermost and update us about your questions. (see  [Kiso Channel]({{< ref "communication.md" >}})). 
+Please feel free to contact us via Mattermost and update us about your questions. (see  [Kiso Channel]({{< ref "communication.md" >}})).
 
 **NOTE:**   An eclipse foundation Mattermost account is needed.


### PR DESCRIPTION
Moved Scope/Personas to hugo documentation.

@HansUweRempler, I'm unsure if [kiso.rempler.de](http://kiso.rempler.de:1313/) is kept up to date.