### PR TITLE
Exclude STM32CubeF7 code from format checks

### DIFF
--- a/thirdparty/stm32cubef7/3rd-party/.clang-format
+++ b/thirdparty/stm32cubef7/3rd-party/.clang-format
@@ -1,0 +1,3 @@
+---
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
This should fix the [**failing Jenkins master**](https://ci.eclipse.org/kiso/job/kiso_github/job/master/).

In the future, please run CI checks before merging!