### PR TITLE
Make Hugo Chapters more readable

### DIFF
--- a/docs/website/content/Contribution guide/bug_report.md
+++ b/docs/website/content/Contribution guide/bug_report.md
@@ -3,6 +3,6 @@ title: "Bug report"
 weight: 9
 ---
 
-# How can I create bug-report?
+### How can I create bug-report?
 
 After provisioning from Eclipse foundation, this part would be clearer. In general, bug report would be based on Bugzilla infrastructure in Eclipse foundation.

--- a/docs/website/content/Contribution guide/c_coding_guidelines.md
+++ b/docs/website/content/Contribution guide/c_coding_guidelines.md
@@ -3,7 +3,7 @@ title: "C Coding Guidelines"
 weight: 3
 ---
 
-# What are the guidelines I need to follow?
+### What are the guidelines I need to follow?
 
 ### Table of Contents
 

--- a/docs/website/content/Contribution guide/communication.md
+++ b/docs/website/content/Contribution guide/communication.md
@@ -3,7 +3,7 @@ title: "Communication Channel"
 weight: 10
 ---
 
-# How can I communicate with the Kiso team?
+### How can I communicate with the Kiso team?
 
 ## Mattermost
 Mattermost is popular in Eclipse community and therefore all eclipse projects channels are hosted in https://mattermost.eclipse.org

--- a/docs/website/content/Contribution guide/dod.md
+++ b/docs/website/content/Contribution guide/dod.md
@@ -3,7 +3,7 @@ title: "DoD"
 weight: 8
 ---
 
-# Definition of Done
+### Definition of Done
 
 
 ## When is my piece of software "done"?

--- a/docs/website/content/Contribution guide/first_contribution.md
+++ b/docs/website/content/Contribution guide/first_contribution.md
@@ -3,9 +3,9 @@ title: "First contribution"
 weight: 2
 ---
 
-## How can I do my first contribution?
+### How can I do my first contribution?
 
-### Prerequisite
+## Prerequisite
 
 Please, before you start writing code, have a look at the personas described in [Kiso's Scope]({{< ref "../Project overview/scope.md" >}}).
 
@@ -13,7 +13,7 @@ They describe who Kiso is targeted for, and should taken into account in your De
 
 Make sure you have done the things in [‘What should I do before I get started?’](../prerequisite). Without accounts, you cannot have access rights to do certain operations. And ECA and DCO are important from a legal point of view, for both contributors and the project. Therefore you need to get them ready before going forward.
 
-### Architecture and source code
+## Architecture and source code
 
 Before you can contribute back something, you need to be pretty familiar with Kiso. First with the architecture of Kiso and then its source code.
 
@@ -21,10 +21,10 @@ Architecture of Kiso is good start point where you can have an overview of the w
 
 Then it is about source code itself. After getting to know the whole picture, you need to zoom in the place you have interests, which more or less means you need to get your hands on code of a certain module, understand it and play around with it.
 
-### Tools and environment setup
+## Tools and environment setup
 
 For an easy jump start of setting up environment and tools, you can find enough information in [Quick start]({{< ref "quick_start.md" >}}).
 
-### Find a good topic to work on
+## Find a good topic to work on
 
 For sure, you want to start with something you have interests in (eg. writing a BSP for a new board).Please contact and talk to us, we will support you in defining and documenting what you would like to do.

--- a/docs/website/content/Contribution guide/prerequisite.md
+++ b/docs/website/content/Contribution guide/prerequisite.md
@@ -3,7 +3,7 @@ title: "Prerequisite"
 weight: 1
 ---
 
-# What should I do before I get started?
+### What should I do before I get started?
 
 
 You need to go through few steps to get the ball rolling. But no worries, it is pretty straightforward.

--- a/docs/website/content/Contribution guide/rules_for_development.md
+++ b/docs/website/content/Contribution guide/rules_for_development.md
@@ -3,7 +3,7 @@ title: "Principles for development"
 weight: 4
 ---
 
-# What are the rules I need to take care of when I contribute?
+### What are the rules I need to take care of when I contribute?
 
 To ensure quality, all contributors need to follow certain set of rules while working on Kiso.
 

--- a/docs/website/content/Contribution guide/unit_testing_guide.md
+++ b/docs/website/content/Contribution guide/unit_testing_guide.md
@@ -3,7 +3,7 @@ title: "Unit Testing Guide"
 weight: 5
 ---
 
-# How should I write my unit tests?
+### How should I write my unit tests?
 
 ## Where to put mockup headers and unit tests
 Along each package we have a `test` directory for it. Its structure resembles a package by itself with include and source directories.

--- a/docs/website/content/Contribution guide/using_cmake.md
+++ b/docs/website/content/Contribution guide/using_cmake.md
@@ -3,7 +3,7 @@ title: "Using CMake"
 weight: 6
 ---
 
-# How is CMake Organized
+### How is CMake Organized
 
 The Kiso project consists of subprojects, all managed by the `CMakeLists.txt` file from the root directory:
 

--- a/docs/website/content/Contribution guide/workflow.md
+++ b/docs/website/content/Contribution guide/workflow.md
@@ -3,7 +3,7 @@ title: "Workflow"
 weight: 7
 ---
 
-# How do I get my contribution into Kiso project?
+### How do I get my contribution into Kiso project?
 
 ## Recommended workflow
 There are more than one way to achieve a goal in git world, however here we recommend the typical way of how contributors contribute to an open source project on github.

--- a/docs/website/content/Frequently asked questions/_index.md
+++ b/docs/website/content/Frequently asked questions/_index.md
@@ -1,10 +1,7 @@
 ---
 title: Frequently asked questions
 weight: 50
-chapter: true
 ---
-
-## Frequently Asked Questions
 
 **Who is Kiso for?**
 

--- a/docs/website/content/Project overview/scope.md
+++ b/docs/website/content/Project overview/scope.md
@@ -3,7 +3,7 @@ title: "Scope"
 weight: 10
 ---
 
-Who and how can Kiso help? Let's look at some user personas to answer this.
+####  Who and how can Kiso help? Let's look at some user personas to answer this.
 
 ## Meet Peter, the embedded device developer ##
 
@@ -21,7 +21,7 @@ are basically of no re-use for Peter.
 
 Thus, Peter typically took some RTOS and integrated HW manufacturer drivers when available. If no drivers had been
 available he wrote them by himself. Over the last couple of years he build up a collection of SW modules and drivers.
-All of this SW modules and drivers are specifically designed for a particular use case and device. For a new project he
+All of these SW modules and drivers are specifically designed for a particular use case and device. For a new project he
 copies over parts of his existing SW set. But, most of these SW parts need modifications in order to fit the new device
 and to become compatible to each other again in a new use case setup.
 

--- a/docs/website/content/Questionnaires/_index.md
+++ b/docs/website/content/Questionnaires/_index.md
@@ -1,12 +1,10 @@
 ---
-title: Questionary
+title: Questionnaires
 weight: 60
-chapter: true
 ---
 
-# Questionnaires
 
-# These anonymous questionnaires give us the chance collect informations helping the contributors community to improve the user experience ..
+### These anonymous questionnaires give us the chance to collect information, helping the contributors community to improve the user experience.
 
 ##  Usability Questionnaire
 

--- a/docs/website/content/_index.md
+++ b/docs/website/content/_index.md
@@ -4,7 +4,7 @@ title: "Eclipse Kiso"
 draft: false
 ---
 
-![Kiso Logo](images/kiso_logo.svg)
+![Kiso Logo](/images/kiso_logo.svg)
 
 # Welcome!
 Eclipse Kiso was designed from scratch as a software development kit for IoT devices and has already been used and verified on a handful of existing products in the market. Eclipse Kiso's reusability, robustness and portability is a key factor which enables fast development and quick time to market for almost all kinds of IoT "things" product development.

--- a/docs/website/layouts/partials/logo.html
+++ b/docs/website/layouts/partials/logo.html
@@ -1,3 +1,3 @@
 <a id="logo" href="{{ .Site.BaseURL }}">
-    <img src="images/kiso_logo.svg" height="80" width="100%" alt="kiso_logo.svg"/>
+    <img src="/images/kiso_logo.svg" height="55" width="100%" alt="kiso_logo.svg"/>
 </a>


### PR DESCRIPTION
 reference issue :Make Hugo Chapters more readable  [#148](https://github.com/eclipse/kiso/issues/148)

-  optimize chapter subtitle description to be rendered in a smaller font.
- fix typos where applicable.
- fix the logo path