### PR TITLE
Fix default build failing when no debugger is installed

### DIFF
--- a/cmake/FlashTarget.cmake
+++ b/cmake/FlashTarget.cmake
@@ -62,7 +62,7 @@ function(CREATE_FLASH_TARGET_JLINK ELF_TARGET)
     if(WSLPATH)
         # 'wslpath -w' to be read directly inside jlink
         execute_process(COMMAND ${WSLPATH} -w ${HEX_TARGET_PATH} OUTPUT_VARIABLE WIN_TARGET_PATH)
-        string(STRIP ${WIN_TARGET_PATH} HEX_TARGET_PATH)
+        string(STRIP "${WIN_TARGET_PATH}" HEX_TARGET_PATH)
     endif()
 
     # \todo: This can be exported to file and replaced with configure_file
@@ -80,7 +80,7 @@ function(CREATE_FLASH_TARGET_JLINK ELF_TARGET)
     if(WSLPATH)
         # 'wslpath -m' so it's not escaped improperly
         execute_process(COMMAND ${WSLPATH} -m ${SCRIPT_PATH} OUTPUT_VARIABLE WIN_SCRIPT_PATH)
-        string(STRIP ${WIN_SCRIPT_PATH} SCRIPT_PATH)
+        string(STRIP "${WIN_SCRIPT_PATH}" SCRIPT_PATH)
     endif()
 
     add_custom_target(flash


### PR DESCRIPTION
* the string STRIP operation fails when passing empty strings
* adding quotes will keep the number and order of parameters consistent

Signed-off-by: elbosch <lars.beseke@bosch.com>