### PR TITLE
Add pipenv to docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline
             containerTemplate
             {
                 name 'kiso-build-env'
-                image 'eclipse/kiso-build-env:v0.0.1'
+                image 'eclipse/kiso-build-env:latest'
                 ttyEnabled true
                 resourceRequestCpu '2'
                 resourceLimitCpu '2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline
             containerTemplate
             {
                 name 'kiso-build-env'
-                image 'eclipse/kiso-build-env:latest'
+                image 'eclipse/kiso-build-env:v0.0.6'
                 ttyEnabled true
                 resourceRequestCpu '2'
                 resourceLimitCpu '2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline
             {
                 name 'kiso-build-env'
                 image 'eclipse/kiso-build-env:v0.0.6'
+                alwaysPullImage 'true'
                 ttyEnabled true
                 resourceRequestCpu '2'
                 resourceLimitCpu '2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline
             {
                 name 'kiso-build-env'
                 image 'eclipse/kiso-build-env:v0.0.6'
-                alwaysPullImage 'true'
                 ttyEnabled true
                 resourceRequestCpu '2'
                 resourceLimitCpu '2'

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update && apt-get install -y \
     ninja-build \
     plantuml \
     python3 \
-    pipenv
+    python3-pip
+
+RUN python3 -m pip install pipenv
 
 ENV WORKON_HOME /kiso-project/.venvs
 ENV PIPENV_CACHE_DIR /kiso-project/.cache

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -25,4 +25,5 @@ RUN apt-get update && apt-get install -y \
     libxml2-utils \
     ninja-build \
     plantuml \
-    python3
+    python3 \
+    pipenv

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -29,4 +29,5 @@ RUN apt-get update && apt-get install -y \
     pipenv
 
 ENV WORKON_HOME /kiso-project/.venvs
+ENV PIPENV_CACHE_DIR /kiso-project/.cache
 RUN chgrp -R 0 /kiso-project && chmod -R g=u /kiso-project

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -27,3 +27,6 @@ RUN apt-get update && apt-get install -y \
     plantuml \
     python3 \
     pipenv
+
+ENV WORKON_HOME /kiso-project/.venvs
+RUN chgrp -R 0 /kiso-project && chmod -R g=u /kiso-project


### PR DESCRIPTION
Dockerfile was updated and new image ([v0.0.6](https://hub.docker.com/layers/eclipse/kiso-build-env/v0.0.6/images/sha256-42a842f17d49cf8aaa772e07ab6f4e33a5a43d35938ec27eda919ca5223b8913?context=explore)) is already available on [Docker Hub](https://hub.docker.com/r/eclipse/kiso-build-env).

`pipenv` is installed via `pip`, **not** via the distributed `apt` package. Reason being, the debain package is over two years at this point. A lot of bugfixes have been made since.