### PR TITLE
Do not always pull docker image in CI/CD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline
             {
                 name 'kiso-build-env'
                 image 'eclipse/kiso-build-env:v0.0.6'
-                alwaysPullImage 'true'
                 ttyEnabled true
                 resourceRequestCpu '2'
                 resourceLimitCpu '2'


### PR DESCRIPTION
`alwaysPullImage` is only needed, if the tagged image were to change between runs. In our case, tags are static and should never change once created.