### PR TITLE
Remove unecessary clutter from dockerfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline
             containerTemplate
             {
                 name 'kiso-build-env'
-                image 'eclipse/kiso-build-env:v0.0.6'
+                image 'eclipse/kiso-build-env:v0.0.7'
                 ttyEnabled true
                 resourceRequestCpu '2'
                 resourceLimitCpu '2'

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -29,7 +29,3 @@ RUN apt-get update && apt-get install -y \
     python3-pip
 
 RUN python3 -m pip install pipenv
-
-ENV WORKON_HOME /kiso-project/.venvs
-ENV PIPENV_CACHE_DIR /kiso-project/.cache
-RUN chgrp -R 0 /kiso-project && chmod -R g=u /kiso-project


### PR DESCRIPTION
The lines I removed have little to no effect on Kiso nor Kiso-Testing. They are probably the result of some trial&error testing with Jenkins for Kiso-Testing. I think I figured out what was going wrong over there, and these changes are now obsolete, hence why I want to remove them.

Docker image tag [v0.0.7](https://hub.docker.com/r/eclipse/kiso-build-env/tags) **already created**.

More details on how I hopefully fixed Kiso-Testing's Jenkins issues [here](https://github.com/ChiefGokhlayehBosch/kiso-testing/commit/4b3d12bcce5f4a3fc6cbf7a38834166b53d69a7d).

These changes in the Dockerfile have **no** effect on the main Kiso repo, they were added during work on Kiso-Testing.